### PR TITLE
Fix: Wrong path to the build.js file.

### DIFF
--- a/lib/urlParser.js
+++ b/lib/urlParser.js
@@ -2,7 +2,10 @@
 
 const { URL } = require('url');
 
-const BUILD_JS_PATH = '../../app/build.js';
+let path = require('path');
+let applicationFolder = path.resolve('.');
+
+const BUILD_JS_PATH = path.resolve(applicationFolder, './app/build.js');
 
 module.exports = environment => {
   function _getHost(req) {


### PR DESCRIPTION
How to reproduce the bug:
* set  $Language: {'//*:*/:language': 'en' } in app/environment.js

Then an error occurs:

Error: Cannot find module '../../app/build.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at _getRootRegExp ([[project_path]]\node_modules\ima-server\lib\urlParser.js:34:19)
    at parseUrl ([[project_path]]\node_modules\ima-server\lib\urlParser.js:128:26)
    at Layer.handle [as handle_request] ([[project_path]]\node_modules\express\lib\router\layer.js:95:5)
    at trim_prefix ([[project_path]]\node_modules\express\lib\router\index.js:317:13)
    at [[project_path]]\node_modules\express\lib\router\index.js:284:7
    at Function.process_params ([[project_path]]\node_modules\express\lib\router\index.js:335:12)

I used workaround based on same principe as in https://github.com/seznam/IMA.js-server/blob/master/index.js
